### PR TITLE
Install script fixes

### DIFF
--- a/lua/glow.lua
+++ b/lua/glow.lua
@@ -40,10 +40,14 @@ local function call_install_script()
       os="Darwin"
       arch=$(uname -m)
     fi
-    [ -z "$arch" ] || [ "$arch" == "unknown" ] && arch="x86_64"
+    if [ -z "$arch" ] || [ "$arch" == "unknown" ]; then
+      arch=$(uname -m)
+      [ "$arch" == "unknown" ] && arch="x86_64"
+    fi
     filename="glow_${version}_${os}_${arch}.tar.gz"
     url="https://github.com/charmbracelet/glow/releases/download/v${version}/${filename}"
 
+    [ -d "$GOPATH/bin" ] || mkdir -p "$GOPATH/bin"
     [ -f "$GOPATH/bin/glow" ] && rm "$GOPATH/bin/glow"
     [ -f glow.tar.gz ] && rm glow.tar.gz
 


### PR DESCRIPTION
This PR changes a couple of things in the install script used in the `call_install_script()` function:

 * Checks whether the directory that the `$GOPATH/bin` points to exists or not. This is useful on systems that have a fresh install of golang (usually from the package manager within the distribution) and have the `$GOPATH` variable set, but don't have the folder created.
 * Falls back to `x86_64` **only** after trying `uname -m` first. This should fix architecture detection on Linux systems whose kernels don't make that information readily available (and are not x86_64).