### PR TITLE
Add config options for border and width

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,54 @@ let g:glow_binary_path = $HOME . "/bin"
 vim.g.glow_binary_path = vim.env.HOME .. "/bin"
 ```
 
+- `glow_border`
+
+Use `g:glow_border` for vimscript config or `vim.g.glow_border` for lua config.
+
+If set, this will change the border of the window. Type `:help nvim_open_win` for border options.
+
+Example:
+
+```viml
+let g:glow_border = "rounded"
+```
+
+```lua
+vim.g.glow_border = "rounded"
+```
+
+- `glow_winhl`
+
+Use `g:glow_winhl` for vimscript config or `vim.g.glow_winhl` for lua config.
+
+If set, this will change the highlight of the window.
+
+Example:
+
+```viml
+let g:glow_winhl = "Normal:MyHighlight"
+```
+
+```lua
+vim.g.glow_winhl = "Normal:MyHighlight"
+```
+
+- `glow_width`
+
+Use `g:glow_width` for vimscript config or `vim.g.glow_width` for lua config.
+
+If set, this will change the width of the window.
+
+Example:
+
+```viml
+let g:glow_width = 120
+```
+
+```lua
+vim.g.glow_width = 120
+```
+
 ## Usage
 
 ```

--- a/README.md
+++ b/README.md
@@ -57,22 +57,6 @@ let g:glow_border = "rounded"
 vim.g.glow_border = "rounded"
 ```
 
-- `glow_winhl`
-
-Use `g:glow_winhl` for vimscript config or `vim.g.glow_winhl` for lua config.
-
-If set, this will change the highlight of the window.
-
-Example:
-
-```viml
-let g:glow_winhl = "Normal:MyHighlight"
-```
-
-```lua
-vim.g.glow_winhl = "Normal:MyHighlight"
-```
-
 - `glow_width`
 
 Use `g:glow_width` for vimscript config or `vim.g.glow_width` for lua config.

--- a/lua/glow.lua
+++ b/lua/glow.lua
@@ -10,7 +10,6 @@ local use_path_glow = vim.g.glow_binary_path == nil and vim.fn.executable("glow"
 local glow_path = use_path_glow and "glow" or bin_path .. "/glow"
 
 local glow_border = vim.g.glow_border
-local glow_winhl = vim.g.glow_winhl
 local glow_width = vim.g.glow_width
 
 local M = {}
@@ -202,9 +201,6 @@ local function open_window(path)
   win = api.nvim_open_win(buf, true, opts)
   api.nvim_buf_set_option(buf, "bufhidden", "wipe")
   api.nvim_win_set_option(win, "winblend", 0)
-  if glow_winhl then
-    api.nvim_win_set_option(win, 'winhl', glow_winhl)
-  end
   api.nvim_buf_set_keymap(buf, "n", "q", ":lua require('glow').close_window()<cr>",
                           {noremap = true, silent = true})
   api.nvim_buf_set_keymap(buf, "n", "<Esc>", ":lua require('glow').close_window()<cr>",

--- a/lua/glow.lua
+++ b/lua/glow.lua
@@ -10,6 +10,7 @@ local use_path_glow = vim.g.glow_binary_path == nil and vim.fn.executable("glow"
 local glow_path = use_path_glow and "glow" or bin_path .. "/glow"
 
 local glow_border = vim.g.glow_border
+local winhl = vim.g.glow_winhl
 
 local M = {}
 
@@ -196,6 +197,9 @@ local function open_window(path)
   win = api.nvim_open_win(buf, true, opts)
   api.nvim_buf_set_option(buf, "bufhidden", "wipe")
   api.nvim_win_set_option(win, "winblend", 0)
+  if winhl then
+    api.nvim_win_set_option(win, 'winhl', winhl)
+  end
   api.nvim_buf_set_keymap(buf, "n", "q", ":lua require('glow').close_window()<cr>",
                           {noremap = true, silent = true})
   api.nvim_buf_set_keymap(buf, "n", "<Esc>", ":lua require('glow').close_window()<cr>",

--- a/lua/glow.lua
+++ b/lua/glow.lua
@@ -10,7 +10,7 @@ local use_path_glow = vim.g.glow_binary_path == nil and vim.fn.executable("glow"
 local glow_path = use_path_glow and "glow" or bin_path .. "/glow"
 
 local glow_border = vim.g.glow_border
-local winhl = vim.g.glow_winhl
+local glow_winhl = vim.g.glow_winhl
 local glow_width = vim.g.glow_width
 
 local M = {}
@@ -180,13 +180,12 @@ local function open_window(path)
   local height = api.nvim_get_option("lines")
   local win_height = math.ceil(height * 0.8 - 4)
   local win_width = math.ceil(width * 0.8)
+  local row = math.ceil((height - win_height) / 2 - 1)
+  local col = math.ceil((width - win_width) / 2)
 
   if glow_width and glow_width < win_width then
     win_width = glow_width
   end
-
-  local row = math.ceil((height - win_height) / 2 - 1)
-  local col = math.ceil((width - win_width) / 2)
 
   local opts = {
     style = "minimal",
@@ -203,8 +202,8 @@ local function open_window(path)
   win = api.nvim_open_win(buf, true, opts)
   api.nvim_buf_set_option(buf, "bufhidden", "wipe")
   api.nvim_win_set_option(win, "winblend", 0)
-  if winhl then
-    api.nvim_win_set_option(win, 'winhl', winhl)
+  if glow_winhl then
+    api.nvim_win_set_option(win, 'winhl', glow_winhl)
   end
   api.nvim_buf_set_keymap(buf, "n", "q", ":lua require('glow').close_window()<cr>",
                           {noremap = true, silent = true})

--- a/lua/glow.lua
+++ b/lua/glow.lua
@@ -9,6 +9,8 @@ local use_path_glow = vim.g.glow_binary_path == nil and vim.fn.executable("glow"
 
 local glow_path = use_path_glow and "glow" or bin_path .. "/glow"
 
+local glow_border = vim.g.glow_border
+
 local M = {}
 
 local function has_value(tab, val)
@@ -186,7 +188,7 @@ local function open_window(path)
     height = win_height,
     row = row,
     col = col,
-    border = "shadow",
+    border = glow_border or "shadow",
   }
 
   -- create preview buffer and set local options

--- a/lua/glow.lua
+++ b/lua/glow.lua
@@ -11,6 +11,7 @@ local glow_path = use_path_glow and "glow" or bin_path .. "/glow"
 
 local glow_border = vim.g.glow_border
 local winhl = vim.g.glow_winhl
+local glow_width = vim.g.glow_width
 
 local M = {}
 
@@ -179,6 +180,11 @@ local function open_window(path)
   local height = api.nvim_get_option("lines")
   local win_height = math.ceil(height * 0.8 - 4)
   local win_width = math.ceil(width * 0.8)
+
+  if glow_width and glow_width < win_width then
+    win_width = glow_width
+  end
+
   local row = math.ceil((height - win_height) / 2 - 1)
   local col = math.ceil((width - win_width) / 2)
 


### PR DESCRIPTION
Hey! I came across glow and this plugin the other day and have already gotten a lot of use out of it. I added a couple of configuration options so I could customize it to work with my current theme and thought it may be worthwhile merging into the main repository. Let me know what you think :) 

## Before
With defaults
![Screen Shot 2021-11-02 at 12 22 36 AM](https://user-images.githubusercontent.com/7513070/139788207-f66a0966-9d53-4a23-9322-05b9aefef65c.png)

## After
Gives the option to set the following
```
vim.g.glow_border = "rounded"
vim.g.glow_width = 120
``` 
![Screen Shot 2021-11-02 at 12 31 38 AM](https://user-images.githubusercontent.com/7513070/139788243-20c735e7-51b7-4b13-a214-79520f42d6d8.png)