### PR TITLE
Add `glow_use_pager` option to show in pager

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,22 @@ let g:glow_width = 120
 vim.g.glow_width = 120
 ```
 
+- `glow_use_pager`
+
+Use `g:glow_use_pager` for vimscript config or `vim.g.glow_use_pager` for lua config.
+
+If set true, `glow` uses the pager to show the doc.
+
+Example:
+
+```viml
+let g:glow_use_pager = v:true
+```
+
+```lua
+vim.g.glow_use_pager = true
+```
+
 ## Usage
 
 ```

--- a/lua/glow.lua
+++ b/lua/glow.lua
@@ -11,6 +11,7 @@ local glow_path = use_path_glow and "glow" or bin_path .. "/glow"
 
 local glow_border = vim.g.glow_border
 local glow_width = vim.g.glow_width
+local glow_use_pager = vim.g.glow_use_pager
 
 local M = {}
 
@@ -206,7 +207,8 @@ local function open_window(path)
   api.nvim_buf_set_keymap(buf, "n", "<Esc>", ":lua require('glow').close_window()<cr>",
                           {noremap = true, silent = true})
 
-  vim.fn.termopen(string.format("%s %s", glow_path, vim.fn.shellescape(path)))
+  local use_pager = glow_use_pager and '-p' or ''
+  vim.fn.termopen(string.format("%s %s %s", glow_path, use_pager, vim.fn.shellescape(path)))
 end
 
 function M.glow(file)


### PR DESCRIPTION
The current build shows the bottom line of the doc because Neovim shows the output from `glow` simply. I want to use `glow -p` to read it more easily by `less`, `more`, etc. .