### PR TITLE
Fix installing instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ A [glow](https://github.com/charmbracelet/glow) preview directly in your neovim 
 with [vim-plug](https://github.com/junegunn/vim-plug)
 
 ```
-Plug 'ellisonleao/glow.nvim'
+Plug 'ellisonleao/glow.nvim', {'branch': 'main'}
 ```
 
 with [packer.nvim](https://github.com/wbthomason/packer.nvim)
 
 ```
-use {"ellisonleao/glow.nvim"}
+use {"ellisonleao/glow.nvim", branch = 'main'}
 ```
 
 ## Configuration


### PR DESCRIPTION
vim-plug and packer pulls from **master** branch by default