### PR TITLE
Fix arch detection on linux

### DIFF
--- a/lua/glow.lua
+++ b/lua/glow.lua
@@ -90,12 +90,13 @@ local function install_glow()
       os = "linux"
     end
     arch = vim.fn.trim(vim.fn.system("uname -p"))
-    if arch == "unknown" then
-      arch = vim.fn.trim(vim.fn.system("uname -m"))
-    end
     if not has_value({ "armv6", "armv7", "i386", "x86_64", "amd64" }, arch) then
-      api.nvim_err_writeln("Architecture not supported/recognized!")
-      return
+      -- if not recognized, try again with uname -m
+      arch = vim.fn.trim(vim.fn.system("uname -m"))
+      if not has_value({ "armv6", "armv7", "i386", "x86_64", "amd64" }, arch) then
+        api.nvim_err_writeln("Architecture not supported/recognized!")
+        return
+      end
     end
     if arch == "amd64" then
       arch = "x86_64"


### PR DESCRIPTION
the problem is ```uname -p``` is non-portable, and on my system( GNU coreutils), it prints the processor type, which is ```AMD Ryzen 7 PRO 4750U with Radeon Graphics```.
I changed the logic to check for ```uname -m``` again when the value from ```uname -p``` is not valid. And it fixed the problem #72  on my machine.