### PR TITLE
fix: allow markdown sub filetypes

### DIFF
--- a/lua/glow/init.lua
+++ b/lua/glow/init.lua
@@ -171,7 +171,7 @@ local function execute(opts)
       return
     end
   else
-    if vim.bo.filetype ~= "markdown" then
+    if not vim.bo.filetype:match("^markdown") then
       vim.notify("preview only works on markdown files", vim.log.levels.ERROR)
       return
     end


### PR DESCRIPTION
Some vim plugins have introduced markdown sub filetypes like `markdown.gfm` ([rhysd/vim-gfm-syntax][1]) and `markdown.pandoc` ([vim-pandoc/vim-pandoc-syntax][2]).
This PR allows such sub filetypes to be previewed.

[1]: https://github.com/rhysd/vim-gfm-syntax
[2]: https://github.com/vim-pandoc/vim-pandoc-syntax
