### PR TITLE
fix: fargs with blank string

### DIFF
--- a/lua/glow/init.lua
+++ b/lua/glow/init.lua
@@ -156,7 +156,7 @@ end
 
 local function execute(opts)
   local file, tmp
-  if not vim.tbl_isempty(opts.fargs) then
+  if not vim.tbl_isempty(opts.fargs) and table.concat(opts.fargs, " ") ~= "" then
     -- check file
     file = opts.fargs[1]
     if not vim.fn.filereadable(file) then


### PR DESCRIPTION

I was trying to run but this error was occurring:

![glow-without-validate ](https://user-images.githubusercontent.com/26947142/180908752-1a3544d5-2d5e-4914-9084-5b50a9962b06.png)


Apparently fargs was coming with an empty string, like this:

`fargs = { "" }`

But I don't really understand why...

I added a validation that fixed the problem, but I'm new to lua and I don't know if it's the best way:

![glow-with-validate](https://user-images.githubusercontent.com/26947142/180908754-3d4eece4-d67b-4129-a241-2cb648ba91c0.png)

