### PR TITLE
[Hot-Fix] -OS not supported #82

### DIFF
--- a/lua/glow/init.lua
+++ b/lua/glow/init.lua
@@ -120,7 +120,7 @@ local function release_file_url()
     return
   end
 
-  local raw_os = jit.os
+  local raw_os = vim.loop.os_uname().sysname
   local raw_arch = jit.arch
   local os_patterns = {
     ["Windows"] = "Windows",


### PR DESCRIPTION
Added the system name name 
:lua print(vim.loop.os_uname().sysname)