### PR TITLE
"OS not supported" also on MacBook Air (M1, 2020) due to architecture patterns

### DIFF
--- a/lua/glow/init.lua
+++ b/lua/glow/init.lua
@@ -62,7 +62,7 @@ local function open_window(cmd, tmp)
   local win_height = math.ceil(height * 0.8)
   local win_width = math.ceil(width * 0.9)
   local row = math.ceil((height - win_height) / 2 - 1)
-  local col = math.ceil((width - win_width) / 2 + 1)
+  local col = math.ceil((width - win_width) / 2)
 
   if glow.config.width and glow.config.width < win_width then
     win_width = glow.config.width

--- a/lua/glow/init.lua
+++ b/lua/glow/init.lua
@@ -134,6 +134,7 @@ local function release_file_url()
     ["x86"] = "i386",
     ["x64"] = "x86_64",
     ["arm"] = "arm7",
+    ["arm64"] = "arm64",
   }
 
   os = os_patterns[raw_os]

--- a/lua/glow/init.lua
+++ b/lua/glow/init.lua
@@ -59,8 +59,8 @@ end
 local function open_window(cmd, tmp)
   local width = vim.o.columns
   local height = vim.o.lines
-  local win_height = math.ceil(height * 0.7)
-  local win_width = math.ceil(width * 0.7)
+  local win_height = math.ceil(height * 0.8)
+  local win_width = math.ceil(width * 0.9)
   local row = math.ceil((height - win_height) / 2 - 1)
   local col = math.ceil((width - win_width) / 2)
 

--- a/lua/glow/init.lua
+++ b/lua/glow/init.lua
@@ -120,7 +120,8 @@ local function release_file_url()
     return
   end
 
-  local raw_os = jit.os
+  -- local raw_os = jit.os
+  local raw_os = vim.loop.os_uname().sysname
   local raw_arch = jit.arch
   local os_patterns = {
     ["Windows"] = "Windows",

--- a/lua/glow/init.lua
+++ b/lua/glow/init.lua
@@ -82,6 +82,13 @@ local function open_window(cmd, tmp)
     border = glow.config.border,
   }
 
+  ----------------------------------------------------------------------------------------
+  -- Debug
+  ----------------------------------------------------------------------------------------
+  vim.pretty_print(win_opts)
+
+  ----------------------------------------------------------------------------------------
+
   -- create preview buffer and set local options
   buf = vim.api.nvim_create_buf(false, true)
   win = vim.api.nvim_open_win(buf, true, win_opts)

--- a/lua/glow/init.lua
+++ b/lua/glow/init.lua
@@ -62,7 +62,7 @@ local function open_window(cmd, tmp)
   local win_height = math.ceil(height * 0.8)
   local win_width = math.ceil(width * 0.9)
   local row = math.ceil((height - win_height) / 2 - 1)
-  local col = math.ceil((width - win_width) / 2)
+  local col = math.ceil((width - win_width) / 2 + 1)
 
   if glow.config.width and glow.config.width < win_width then
     win_width = glow.config.width


### PR DESCRIPTION
@ellisonleao I am also getting "OS not supported" on MacBook Air (M1, 2020), this time due to the jit.arch.
I'm getting:  `lua print(jit.arch) = "arm64"`, so I did this:
```
  local arch_patterns = {
    ["x86"] = "i386",
    ["x64"] = "x86_64",
    ["arm"] = "arm7",
    ["arm64"] = "arm64",
  }

```