### PR TITLE
fix(extension): Allow upper/lower case extension

### DIFF
--- a/lua/glow/init.lua
+++ b/lua/glow/init.lua
@@ -145,7 +145,7 @@ end
 
 local function is_md_ext(ext)
   local allowed_exts = { "md", "markdown", "mkd", "mkdn", "mdwn", "mdown", "mdtxt", "mdtext", "rmd", "wiki" }
-  if not vim.tbl_contains(allowed_exts, ext) then
+  if not vim.tbl_contains(allowed_exts, string.lower(ext)) then
     return false
   end
   return true


### PR DESCRIPTION
Plugin didn't work on README.MD due to the upper case, this should allow all cases 😉