### PR TITLE
fix: install script for windows

### DIFF
--- a/lua/glow/init.lua
+++ b/lua/glow/init.lua
@@ -106,6 +106,7 @@ local function release_file_url()
   local raw_arch = jit.arch
   local os_patterns = {
     ["Windows"] = "Windows",
+    ["Windows_NT"] = "Windows",
     ["Linux"] = "linux",
     ["Darwin"] = "Darwin",
     ["BSD"] = "freebsd",
@@ -126,14 +127,8 @@ local function release_file_url()
     return ""
   end
 
-  -- win install not supported for now
-  if os == "Windows" then
-    vim.notify("install script not supported on Windows yet. Please install glow manually", vim.log.levels.WARN)
-    return ""
-  end
-
   -- create the url, filename based on os, arch, version
-  local filename = "glow_" .. version .. "_" .. os .. "_" .. arch .. ".tar.gz"
+  local filename = "glow_" .. version .. "_" .. os .. "_" .. arch .. (os == "Windows" and ".zip" or ".tar.gz")
   return "https://github.com/charmbracelet/glow/releases/download/v" .. version .. "/" .. filename
 end
 


### PR DESCRIPTION
Closes #94 

Changed 2 lines of code to let the install script work on Windows (download a .zip on Windows instead of .tar.gz, added extra raw_os -> os pattern). Seems to work on my windows 11 computers using the built-in `tar`/`curl`.

- Not sure if more testing needed. I checked whether `:Glow` auto-installs the binary and properly renders markdown.
- Not sure whether the `glow` binary should still be in `~/.local/bin/` on Windows by default (maybe something like `vim.fn.stdpath('data')/glow/` like how https://github.com/williamboman/mason.nvim stores language servers?) but I personally don't mind it being there.