### PR TITLE
fix: blank preview w/ glow 1.5.0

### DIFF
--- a/lua/glow.lua
+++ b/lua/glow.lua
@@ -23,7 +23,6 @@ local function stop_job()
   if job_id == nil then
     return
   end
-  -- print("stopping job: " .. vim.inspect(job_id))
   vim.fn.jobstop(job_id)
   job_id = nil
 end
@@ -94,25 +93,6 @@ local function open_window(cmd)
   }
 
   job_id = vim.fn.termopen(cmd, term_opts)
-
-  -- local chan = vim.api.nvim_open_term(buf, {})
-  -- print("command for job: " .. vim.inspect(cmd))
-  -- print("starting job to communicate on channel: " .. vim.inspect(chan))
-  -- job_id = vim.fn.jobstart(cmd, {
-  --   on_stdout = function(_, data, name)
-      -- print("[" .. vim.inspect(name) .."] data before iter: " .. vim.inspect(data))
-  --     for _, d in ipairs(data) do
-        -- print("[" .. vim.inspect(name) .."] sending on channel: " .. vim.inspect(chan))
-        -- print("[" .. vim.inspect(name) .."] sending data: " .. vim.inspect(d))
-   --      vim.api.nvim_chan_send(chan, d .. "\r\n")
-   --    end
-   --  end,
-   --  on_exit = function(job_id, code, _)
-   --    print("job " .. vim.inspect(job_id) .. " exited w/ code: " .. vim.inspect(code))
-   --  end,
-   --  pty = true,
-  -- })
-  -- print("job started: " .. vim.inspect(job_id))
 
   if glow.config.pager then
     vim.cmd("startinsert")

--- a/lua/glow.lua
+++ b/lua/glow.lua
@@ -101,7 +101,7 @@ end
 
 local function release_file_url()
   local os, arch
-  local version = "1.4.1"
+  local version = "1.5.0"
 
   -- check pre-existence of required programs
   if vim.fn.executable("curl") == 0 or vim.fn.executable("tar") == 0 then

--- a/lua/glow.lua
+++ b/lua/glow.lua
@@ -17,6 +17,7 @@ local function stop_job()
   if job_id == nil then
     return
   end
+  print("stopping job: " .. vim.inspect(job_id))
   vim.fn.jobstop(job_id)
   job_id = nil
 end
@@ -88,13 +89,22 @@ local function open_window(cmd, tmp)
   }
 
   local chan = vim.api.nvim_open_term(buf, cbs)
+  print("command for job: " .. vim.inspect(cmd))
+  print("starting job to communicate on channel: " .. vim.inspect(chan))
   job_id = vim.fn.jobstart(cmd, {
-    on_stdout = function(_, data, _)
+    on_stdout = function(_, data, name)
+      print("[" .. vim.inspect(name) .."] data before iter: " .. vim.inspect(data))
       for _, d in ipairs(data) do
+        print("[" .. vim.inspect(name) .."] sending on channel: " .. vim.inspect(chan))
+        print("[" .. vim.inspect(name) .."] sending data: " .. vim.inspect(d))
         vim.api.nvim_chan_send(chan, d .. "\r\n")
       end
     end,
+    on_exit = function(job_id, code, _)
+      print("job " .. vim.inspect(job_id) .. " exited w/ code: " .. vim.inspect(code))
+    end,
   })
+  print("job started: " .. vim.inspect(job_id))
 
   if glow.config.pager then
     vim.cmd("startinsert")

--- a/lua/glow.lua
+++ b/lua/glow.lua
@@ -114,7 +114,7 @@ local function open_window(cmd_args)
   local function on_output(err, data)
     if err then
       -- what should we really do here?
-      print("[Glow Error] " .. vim.inspect(err))
+      vim.api.nvim_err_writeln("[Glow Error] " .. vim.inspect(err))
     end
     if data then
       local lines = vim.split(data, "\n")

--- a/lua/glow.lua
+++ b/lua/glow.lua
@@ -22,7 +22,7 @@ end
 
 local function safe_close(h)
   if not h:is_closing() then
-      h:close()
+    h:close()
   end
 end
 
@@ -114,12 +114,12 @@ local function open_window(cmd_args)
   local function on_output(err, data)
     if err then
       -- what should we really do here?
-      print("[Glow Error] "..vim.inspect(err))
+      print("[Glow Error] " .. vim.inspect(err))
     end
     if data then
       local lines = vim.split(data, "\n")
       for _, d in ipairs(lines) do
-        vim.api.nvim_chan_send(chan, d.."\r\n")
+        vim.api.nvim_chan_send(chan, d .. "\r\n")
       end
     end
   end
@@ -139,7 +139,7 @@ local function open_window(cmd_args)
   local cmd = table.remove(cmd_args, 1)
   local job_opts = {
     args = cmd_args,
-    stdio = {nil, job.stdout, job.stderr},
+    stdio = { nil, job.stdout, job.stderr },
   }
 
   job.handle = vim.loop.spawn(cmd, job_opts, vim.schedule_wrap(on_exit))


### PR DESCRIPTION
While using the semantics introduced in https://github.com/ellisonleao/glow.nvim/commit/83f184063095ab9928175d9c4abafd8d0ac83700, glow 1.5.0 is immediately `SIGTERM`'d upon execution of `jobstart()`.  During testing, it was observed that the introduction of `pty = true` to the options for `jobstart()` would allow for successful execution while leveraging the linked executions semantics (avoiding the `SIGTERM`), but output would render very slowly (~2-5 seconds).  Avoiding the `job_control` semantics and leveraging `vim.loop` directly appears to allow for successful output presentation and avoid delayed output rendering.

This PR also bumps the glow version to `1.5.0`.