### PR TITLE
Add fallback to `termopen()` for Windows

### DIFF
--- a/lua/glow.lua
+++ b/lua/glow.lua
@@ -87,7 +87,7 @@ local function open_window(cmd, tmp)
     end,
   }
 
-  if vim.loop.os_uname().sysname:find('Windows') then
+  if vim.loop.os_uname().sysname:find("Windows") then
     job_id = vim.fn.termopen(cmd, cbs)
   else
     local chan = vim.api.nvim_open_term(buf, cbs)

--- a/lua/glow.lua
+++ b/lua/glow.lua
@@ -87,14 +87,17 @@ local function open_window(cmd, tmp)
     end,
   }
 
-  local chan = vim.api.nvim_open_term(buf, cbs)
-  job_id = vim.fn.jobstart(cmd, {
-    on_stdout = function(_, data, _)
-      for _, d in ipairs(data) do
-        vim.api.nvim_chan_send(chan, d .. "\r\n")
-      end
-    end,
-  })
+  if vim.loop.os_uname().sysname:find('Windows') then
+    job_id = vim.fn.termopen(cmd, cbs)
+  else
+    job_id = vim.fn.jobstart(cmd, {
+      on_stdout = function(_, data, _)
+        for _, d in ipairs(data) do
+          vim.api.nvim_chan_send(chan, d .. "\r\n")
+        end
+      end,
+    })
+  end
 
   if glow.config.pager then
     vim.cmd("startinsert")

--- a/lua/glow.lua
+++ b/lua/glow.lua
@@ -90,6 +90,7 @@ local function open_window(cmd, tmp)
   if vim.loop.os_uname().sysname:find('Windows') then
     job_id = vim.fn.termopen(cmd, cbs)
   else
+    local chan = vim.api.nvim_open_term(buf, cbs)
     job_id = vim.fn.jobstart(cmd, {
       on_stdout = function(_, data, _)
         for _, d in ipairs(data) do


### PR DESCRIPTION
`nvim_open_term()` seems to not work for glow on Windows, falling back to `termopen()` for Windows should work for now.
above img is before, bottom is after:
![image](https://user-images.githubusercontent.com/43484729/218088775-4bc38d62-c2ce-46a6-aa04-c3292d4736ad.png)
![image](https://user-images.githubusercontent.com/43484729/218088870-0af1bc99-53e7-42e4-b506-32ee5f57a3c6.png)
