### PR TITLE
Fix incorrect filename pattern

### DIFF
--- a/lua/glow.lua
+++ b/lua/glow.lua
@@ -198,7 +198,7 @@ local function release_file_url()
   local os_patterns = {
     ["Windows"] = "Windows",
     ["Windows_NT"] = "Windows",
-    ["Linux"] = "linux",
+    ["Linux"] = "Linux",
     ["Darwin"] = "Darwin",
     ["BSD"] = "freebsd",
   }
@@ -218,8 +218,8 @@ local function release_file_url()
     return ""
   end
 
-  -- create the url, filename based on os, arch, version
-  local filename = "glow_" .. version .. "_" .. os .. "_" .. arch .. (os == "Windows" and ".zip" or ".tar.gz")
+  -- create the url, filename based on os and arch
+  local filename = "glow_" .. os .. "_" .. arch .. (os == "Windows" and ".zip" or ".tar.gz")
   return "https://github.com/charmbracelet/glow/releases/download/v" .. version .. "/" .. filename
 end
 


### PR DESCRIPTION
The filename pattern is changed in recent releases of glow. Take linux/x86_64 as an exmaple.

|version|filename|
|-------|-----------|
|1.4.1 |glow_1.4.1_linux_x86_64.tar.gz |
|1.5.0| glow_1.5.0_Linux_x86_64.tar.gz |
|1.5.1| glow_Linux_x86_64.tar.gz |

Here lists the change:
- In version 1.5.0, os name is changed from "linux" to "Linux".
- In version 1.5.1, version number is excluded.

We fix this issue in this patch.
Please help review it. Thanks.