### PR TITLE
feat(#138): added configurable `fts` and `exts`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@
   </p>
   <img src="https://img.shields.io/badge/Made%20with%20Lua-blueviolet.svg?style=for-the-badge&logo=lua" />
   <img src="https://img.shields.io/github/actions/workflow/status/ellisonleao/glow.nvim/default.yml?style=for-the-badge" />
-  
+
 </div>
 
-https://user-images.githubusercontent.com/178641/215353259-eb8688fb-5600-4b95-89a2-0f286e3b6441.mp4
+<https://user-images.githubusercontent.com/178641/215353259-eb8688fb-5600-4b95-89a2-0f286e3b6441.mp4>
 
 **Breaking changes are now moved to a fixed topic in Discussions. [Click here](https://github.com/ellisonleao/glow.nvim/discussions/77) to see them**
 
@@ -60,6 +60,10 @@ The script comes with the following defaults:
   height = 100,
   width_ratio = 0.7, -- maximum width of the Glow window compared to the nvim window size (overrides `width`)
   height_ratio = 0.7,
+  filetypes = { "markdown", "markdown.pandoc", "markdown.gfm", "wiki", "vimwiki", "telekasten" },
+  extra_filetypes = {},
+  extensions = { "md", "markdown", "mkd", "mkdn", "mdwn", "mdown", "mdtxt", "mdtext", "rmd", "wiki" },
+  extra_extensions = {},
 }
 ```
 

--- a/lua/glow.lua
+++ b/lua/glow.lua
@@ -24,6 +24,10 @@ local glow = {}
 ---@field pager boolean display output in pager style
 ---@field width integer floating window width
 ---@field height integer floating window height
+---@field filetypes table allowed filetypes
+---@field extra_filetypes table aditional filetypes
+---@field extensions table allowed extensions
+---@field extra_extensions table aditional extensions
 -- default configurations
 local config = {
   glow_path = vim.fn.exepath("glow"),
@@ -33,6 +37,10 @@ local config = {
   pager = false,
   width = 100,
   height = 100,
+  filetypes = { "markdown", "markdown.pandoc", "markdown.gfm", "wiki", "vimwiki", "telekasten" },
+  extra_filetypes = {},
+  extensions = { "md", "markdown", "mkd", "mkdn", "mdwn", "mdown", "mdtxt", "mdtext", "rmd", "wiki" },
+  extra_extensions = {},
 }
 
 -- default configs
@@ -225,7 +233,7 @@ end
 
 ---@return boolean
 local function is_md_ft()
-  local allowed_fts = { "markdown", "markdown.pandoc", "markdown.gfm", "wiki", "vimwiki", "telekasten" }
+  local allowed_fts = vim.tbl_deep_extend("force", glow.config.filetypes, glow.config.extra_filetypes)
   if not vim.tbl_contains(allowed_fts, vim.bo.filetype) then
     return false
   end
@@ -234,7 +242,7 @@ end
 
 ---@return boolean
 local function is_md_ext(ext)
-  local allowed_exts = { "md", "markdown", "mkd", "mkdn", "mdwn", "mdown", "mdtxt", "mdtext", "rmd", "wiki" }
+  local allowed_exts = vim.tbl_deep_extend("force", glow.config.extensions, glow.config.extra_extensions)
   if not vim.tbl_contains(allowed_exts, string.lower(ext)) then
     return false
   end

--- a/tests/glow/glow_spec.lua
+++ b/tests/glow/glow_spec.lua
@@ -11,6 +11,10 @@ describe("setup", function()
       pager = false,
       width = 100,
       height = 100,
+      filetypes = { "markdown", "markdown.pandoc", "markdown.gfm", "wiki", "vimwiki", "telekasten" },
+      extra_filetypes = {},
+      extensions = { "md", "markdown", "mkd", "mkdn", "mdwn", "mdown", "mdtxt", "mdtext", "rmd", "wiki" },
+      extra_extensions = {},
     }
     glow.setup()
     assert.are.same(glow.config, expected)
@@ -25,6 +29,10 @@ describe("setup", function()
       pager = true,
       width = 200,
       height = 100,
+      filetypes = { "markdown", "markdown.pandoc" },
+      extra_filetypes = { "wiki" },
+      extensions = { "md", "markdown", "mkd", "mkdn" },
+      extra_extensions = { "mdtext" },
     }
     glow.setup(expected)
     assert.are.same(glow.config, expected)


### PR DESCRIPTION
With this PR we achieve a more personal configuration while keeping the defaults if the user doesn't want to change the behaviour in relation to `filetypes` and `extensions`.

- [x] Added configurable `filetypes` and `extensions`
  - Added `extra_filetypes` and `extra_extensions` for better user experience (keeping the defaults while extending them)
- [x] Updated documentation
- [x] Updated tests

<details>
<summary>Test Results</summary>

```bash
Starting...
Scheduling: tests//glow/glow_spec.lua

========================================
Testing:        /path/to/nvim_plugins/glow.nvim/tests/glow/glow_spec.lua
Success ||      setup setup with default configs
Success ||      setup setup with custom configs

Success:        2
Failed :        0
Errors :        0
========================================
```

</details>

Closes #138