### PR TITLE
feat: added nvim v0.10.0 deprecated api support

### DIFF
--- a/lua/glow.lua
+++ b/lua/glow.lua
@@ -128,9 +128,15 @@ local function open_window(cmd_args)
   win = vim.api.nvim_open_win(buf, true, win_opts)
 
   -- options
-  vim.api.nvim_win_set_option(win, "winblend", 0)
-  vim.api.nvim_buf_set_option(buf, "bufhidden", "wipe")
-  vim.api.nvim_buf_set_option(buf, "filetype", "glowpreview")
+  if vim.version().minor >= 10 then
+    vim.api.nvim_set_option_value("winblend", 0, { scope = "local", win = win })
+    vim.api.nvim_set_option_value("bufhidden", "wipe", { scope = "local", buf = buf })
+    vim.api.nvim_set_option_value("filetype", "glowpreview", { scope = "local", buf = buf })
+  else
+    vim.api.nvim_win_set_option(win, "winblend", 0)
+    vim.api.nvim_buf_set_option(buf, "bufhidden", "wipe")
+    vim.api.nvim_buf_set_option(buf, "filetype", "glowpreview")
+  end
 
   -- keymaps
   local keymaps_opts = { silent = true, buffer = buf }


### PR DESCRIPTION
# Changes made

- [x] If the version is v0.10.0 or higher use the new API.

`vim.api.nvim_win_set_option` and `vim.api.nvim_buf_set_option` are combined into `vim.api.nvim_set_option_value` from v0.10.0 onwards.

## Reference

- [Deprecated API changes from v0.10.0 onwards](https://neovim.io/doc/user/deprecated.html#deprecated-0.10)